### PR TITLE
Clarify Overview so the Central summary distinguishes openai

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,7 +1,6 @@
 ## Overview
-[OpenAI](https://openai.com/) provides a suite of powerful AI models and services for natural language processing, code generation, image understanding, and more.
 
-The OpenAI connector offers APIs to easily connect and interact with [OpenAI's RESTful API](https://openai.com/api/) endpoints, enabling seamless integration with models such as GPT, Whisper, and DALL·E.
+The `openai` module is a comprehensive, fully-typed REST connector that covers OpenAI's entire [REST API](https://platform.openai.com/docs/api-reference) — including chat completions, responses, assistants, audio, images, embeddings, batches, files, and fine-tuning — in a single client. Use it for direct, low-level access to any OpenAI endpoint; for a single endpoint group use a focused connector such as `openai.chat` or `openai.audio`, and for the `ballerina/ai` agent framework use `ai.openai`.
 
 ### Key Features
 - Access to advanced AI models including GPT-4o, GPT-4, and GPT-3.5


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it selects a library. Across the OpenAI / Azure OpenAI / `ai.*` packages this first paragraph was a generic vendor blurb, so their summaries were nearly identical and an agent could not reliably tell them apart (e.g. an agent-framework model provider vs a direct REST connector).

### Change

Rewrite the Overview's first paragraph into a single, **capability-first** sentence that states what this module uniquely is — grounded in its actual API and `Ballerina.toml` type keywords — so the summary alone disambiguates it from its siblings. The now-redundant generic second paragraph is merged away. **Key Features** and everything below are untouched; `Module.md` is synced where present.

> Draft: opening for wording review. Part of a coordinated pass to disambiguate the AI/LLM package summaries surfaced by Copilot library search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)